### PR TITLE
Fixed ParseBuf index underrun

### DIFF
--- a/retcl-0.1.0.tm
+++ b/retcl-0.1.0.tm
@@ -451,7 +451,7 @@ oo::class create retcl {
                 # Non-empty Bulk String
                 incr eol 2
                 set endIdx [expr {$eol+$bulkLen-1}]
-                if {[string length $buffer] < $endIdx} {
+                if {[string length $buffer] < [expr {$endIdx+2}]} {
                     # Need to wait for more input
                     return
                 }


### PR DESCRIPTION
If the bulk data read did not return the cr/lf, the condition was met to process the data and the index was incremented beyond the end of the buffer.  Since the buffer was empty, it was reset and the read event returned.  On the next read event, for just the cr/lf, TypeName would throw an error for an invalid type - "cr".
